### PR TITLE
Fixes

### DIFF
--- a/server/src/main/java/com/voipfuture/jminesweep/server/cell/GameBoard.java
+++ b/server/src/main/java/com/voipfuture/jminesweep/server/cell/GameBoard.java
@@ -1,6 +1,7 @@
 package com.voipfuture.jminesweep.server.cell;
 
 import com.voipfuture.jminesweep.shared.Difficulty;
+import com.voipfuture.jminesweep.shared.terminal.ANSIScreenRenderer;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -41,16 +42,23 @@ public class GameBoard {
             case LOST -> renderDefeatScreen();
         };
     }
-    private String renderOngoingGame() {
-        final StringBuilder builder = new StringBuilder();
 
+    private String renderOngoingGame() {
+        final ANSIScreenRenderer r = new ANSIScreenRenderer();
+        r.clearScreen();
+
+        final StringBuilder row = new StringBuilder();
+        int y = 0;
         for (GameCell[] gameCell : gameCells) {
+            row.setLength( 0 );
             for (int j = 0; j < gameCells[0].length; ++j) {
-                builder.append(gameCell[j].getClientGuiCell());
+                row.append(gameCell[j].getClientGuiCell());
             }
-            builder.append("\n");
+            r.printTextAt( row.toString(), 0, y );
+            y++;
         }
-        return builder.toString();
+        r.moveCursor( cursorPosition[0]*3+1, cursorPosition[1] );
+        return r.getScreenContents();
     }
 
     private String renderVictoryScreen() {

--- a/server/src/main/java/com/voipfuture/jminesweep/server/cell/GameBoard.java
+++ b/server/src/main/java/com/voipfuture/jminesweep/server/cell/GameBoard.java
@@ -35,15 +35,15 @@ public class GameBoard {
                 .allMatch(cell -> cell.getCellState() == GameCell.CellState.FLAGGED);
     }
 
-    public String render() {
+    public String render(boolean debugMode) {
         return switch (gameState) {
-            case ONGOING -> renderOngoingGame();
+            case ONGOING -> renderOngoingGame(debugMode);
             case WON -> renderVictoryScreen();
             case LOST -> renderDefeatScreen();
         };
     }
 
-    private String renderOngoingGame() {
+    private String renderOngoingGame(boolean debugMode) {
         final ANSIScreenRenderer r = new ANSIScreenRenderer();
         r.clearScreen();
 
@@ -52,7 +52,13 @@ public class GameBoard {
         for (GameCell[] gameCell : gameCells) {
             row.setLength( 0 );
             for (int j = 0; j < gameCells[0].length; ++j) {
-                row.append(gameCell[j].getClientGuiCell());
+                if ( debugMode )
+                {
+                    boolean isBomb = gameCell[j] instanceof BombCell;
+                    row.append( "[" ).append( isBomb ? GameCell.BOMB_CELL_ICON : GameCell.EMPTY_CELL_ICON ).append( "]" );
+                } else {
+                    row.append(gameCell[j].getClientGuiCell());
+                }
             }
             r.printTextAt( row.toString(), 0, y );
             y++;


### PR DESCRIPTION
Hi,

I did a  few minor changes/fixes:

- you accidently transmitted the screen content payload length as a string of integer (new String(Utils.intToNet(..)) instead of just the 4 integer bytes
- I removed the BufferedWriter and OutputStreamWriter as you don't need them, just the OutputStream will do fine.  Closing a socket's input and output streams is not needed , those are closed automatically when you close the socket (check the Socket#close JavaDoc)
- while at it, I also changed the server to not terminate whenever a client disconnects
- to make debugging easier, I added support for the "TOGGLE_DEBUG_MODE" (client key '#') to toggle between a "all bombs revealed" view and the regular one
- the "General requirements" section mentions that the client will use an ANSI terminal so IMHO you should make use of  the ANSIScreenRenderer class I wrote for this purpose as it makes for a much better UX. I've taken the liberty to adopt your renderOngoingGame() method to use this class

While looking at your code I saw that you made the same mistake I did ;) when implementing the Minesweeper algorithm for the first time ... for any cell, Minesweeper displays the number bombs in **adjacent**/surrounding cells **only** , so findSurroundingCells() has to exclude the current cell which you're not doing right now.

So for 

|B|B|B|
|-|-|-|
|B|B|B|
|B|B|B

(assuming this is somewhere in the middle of the board with no other bombs around it) you would return

|3|5|3|
|-|-|-|
|5|8|5|
|3|5|3|